### PR TITLE
Switch to noble service scanning

### DIFF
--- a/examples/eddystone.js
+++ b/examples/eddystone.js
@@ -23,7 +23,7 @@
 * SOFTWARE.
 */
 
-var webbluetooth = require('../');
+var webbluetooth = require("../");
 
 var eddystoneUUID = 0xFEAA;
 

--- a/examples/heartrate.js
+++ b/examples/heartrate.js
@@ -23,30 +23,30 @@
 * SOFTWARE.
 */
 
-var bluetooth = require('../').bluetooth;
+var bluetooth = require("../").bluetooth;
 
-console.log('Requesting Bluetooth Devices...');
+console.log("Requesting Bluetooth Devices...");
 bluetooth.requestDevice({
 	filters:[{ services:[ "heart_rate" ] }]
 })
 .then(device => {
-	console.log('Found device: ' + device.name);
+	console.log("Found device: " + device.name);
 	return device.gatt.connect();
 })
 .then(server => {
-	console.log('Gatt server connected: ' + server.connected);
+	console.log("Gatt server connected: " + server.connected);
 	return server.getPrimaryService("heart_rate");
 })
 .then(service => {
-	console.log('Primary service: ' + service.uuid);
+	console.log("Primary service: " + service.uuid);
 	return service.getCharacteristic("heart_rate_measurement");
 })
 .then(characteristic => {
-	console.log('Characteristic: ' + characteristic.uuid);
+	console.log("Characteristic: " + characteristic.uuid);
 	return characteristic.startNotifications();
 })
 .then(characteristic => {
-	console.log('Notifications started');
+	console.log("Notifications started");
 
 	characteristic.addEventListener("characteristicvaluechanged", event => {
 		if (event.value.buffer.byteLength) console.log(event.value.getUint16(0));

--- a/examples/selector.js
+++ b/examples/selector.js
@@ -23,13 +23,13 @@
 * SOFTWARE.
 */
 
-var Bluetooth = require('../').Bluetooth;
+var Bluetooth = require("../").Bluetooth;
 var bluetoothDevices = [];
 
-process.stdin.setEncoding('utf8');
-process.stdin.on('readable', () => {
+process.stdin.setEncoding("utf8");
+process.stdin.on("readable", () => {
     var input = process.stdin.read();
-    if (input === '\u0003') {
+    if (input === "\u0003") {
         process.exit();
     } else {
         var index = parseInt(input);
@@ -52,7 +52,11 @@ function handleDeviceFound(bluetoothDevice, selectFn) {
     }
 
     bluetoothDevices.push({ id: bluetoothDevice.id, select: selectFn });
+
     console.log(bluetoothDevices.length + ": " + bluetoothDevice.name);
+    if (bluetoothDevice._serviceUUIDs.length) {
+        console.log("\tAdvertising: " + bluetoothDevice._serviceUUIDs);
+    }
 }
 
 var bluetooth = new Bluetooth({

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -85,7 +85,7 @@ export class NobleAdapter extends EventEmitter implements Adapter {
         return (noble.state === "poweredOn");
     }
 
-    private init(completeFn: () => any) {
+    private init(completeFn: () => any): void {
         if (this.initialised) return completeFn();
         noble.on("discover", deviceInfo => {
             if (this.discoverFn) this.discoverFn(deviceInfo);
@@ -105,13 +105,13 @@ export class NobleAdapter extends EventEmitter implements Adapter {
         };
     }
 
-    private bufferToDataView(buffer) {
+    private bufferToDataView(buffer: Buffer): DataView {
         // Buffer to ArrayBuffer
         const arrayBuffer = new Uint8Array(buffer).buffer;
         return new DataView(arrayBuffer);
     }
 
-    private dataViewToBuffer(dataView) {
+    private dataViewToBuffer(dataView: DataView): Buffer {
         // DataView to TypedArray
         const typedArray = new Uint8Array(dataView.buffer);
         return new Buffer(typedArray);
@@ -151,11 +151,11 @@ export class NobleAdapter extends EventEmitter implements Adapter {
         const manufacturerData = new Map();
         if (deviceInfo.advertisement.manufacturerData) {
             // First 2 bytes are 16-bit company identifier
-            let company = deviceInfo.advertisement.manufacturerData.readUInt16LE(0);
-            company = ("0000" + company.toString(16)).slice(-4);
+            const company = deviceInfo.advertisement.manufacturerData.readUInt16LE(0);
+
             // Remove company ID
             const buffer = deviceInfo.advertisement.manufacturerData.slice(2);
-            manufacturerData.set(company, this.bufferToDataView(buffer));
+            manufacturerData.set(("0000" + company.toString(16)).slice(-4), this.bufferToDataView(buffer));
         }
 
         const serviceData = new Map();

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -169,25 +169,13 @@ export class NobleAdapter extends EventEmitter implements Adapter {
     }
 
     public startScan(serviceUUIDs: Array<string>, foundFn: (device: Partial<BluetoothDevice>) => void, completeFn?: () => void, errorFn?: (errorMsg: string) => void): void {
-
-        if (serviceUUIDs.length === 0) {
-            this.foundFn = foundFn;
-        } else {
-            this.foundFn = device => {
-                serviceUUIDs.forEach(serviceUUID => {
-                    if (device._serviceUUIDs.indexOf(serviceUUID) >= 0) {
-                        foundFn(device);
-                        return;
-                    }
-                });
-            };
-        }
+        this.foundFn = foundFn;
 
         this.init(() => {
             this.deviceHandles = {};
             function stateCB() {
                 if (this.state === true) {
-                    noble.startScanning([], false, this.checkForError(errorFn, completeFn));
+                    noble.startScanning(serviceUUIDs, true, this.checkForError(errorFn, completeFn));
                 } else {
                     errorFn("adapter not enabled");
                 }

--- a/src/device.ts
+++ b/src/device.ts
@@ -69,7 +69,7 @@ export class BluetoothDevice extends EventDispatcher {
      */
     public readonly adData: {
         rssi?: number;
-        txPower?: null;
+        txPower?: number;
         serviceData?: Map<string, DataView>;
         manufacturerData?: Map<string, DataView>;
     };

--- a/src/service.ts
+++ b/src/service.ts
@@ -122,8 +122,11 @@ export class BluetoothRemoteGATTService extends EventDispatcher {
             function complete() {
                 if (!characteristic) return resolve(this.characteristics);
 
+                // Canonical-ize characteristic
+                characteristic = getCharacteristicUUID(characteristic);
+
                 const filtered = this.characteristics.filter(characteristicObject => {
-                    return (characteristicObject.uuid === getCharacteristicUUID(characteristic));
+                    return (characteristicObject.uuid === characteristic);
                 });
 
                 if (filtered.length !== 1) return reject("getCharacteristics error: characteristic not found");


### PR DESCRIPTION
Noble service scanning seems to now support canonical UUIDs and short UUIDs and vice-versa (on MacOS at least)

This PR switches to use the noble scanning methods which finds lesser-advertised services.
Also made it more aggresive.

Also includes some minor example updates.

@vshymanskyy this should fix #5 