### PR TITLE
Allow local build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build
 prebuilds
 dist
 docs
+.idea

--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,7 @@
 .DS_Store
 .vscode
+.idea
 .gitignore
-SimpleBLE
 node_modules
 build
 src

--- a/.npmignore
+++ b/.npmignore
@@ -1,9 +1,8 @@
-/.DS_Store
+.DS_Store
 .vscode
 .idea
 .gitignore
-/node_modules
-/build
-/src
-/index.html
-/firmware
+node_modules
+build
+index.html
+firmware

--- a/.npmignore
+++ b/.npmignore
@@ -1,9 +1,9 @@
-.DS_Store
+/.DS_Store
 .vscode
 .idea
 .gitignore
-node_modules
-build
-src
-index.html
-firmware
+/node_modules
+/build
+/src
+/index.html
+/firmware

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "bluetooth"
   ],
   "scripts": {
-    "install": "prebuild-install --backend cmake-js --runtime napi || cmake-js rebuild",
+    "install": "ls -la SimpleBLE && ls -la SimpleBLE/simpleble && prebuild-install --backend cmake-js --runtime napi || cmake-js rebuild",
     "clean": "yarn clean:cpp && yarn clean:ts",
     "clean:cpp": "cmake-js clean && git clean -fx ./prebuilds",
     "clean:ts": "git clean -fx ./dist ./docs",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "bluetooth"
   ],
   "scripts": {
-    "install": "ls -la SimpleBLE && ls -la SimpleBLE/simpleble && prebuild-install --backend cmake-js --runtime napi || cmake-js rebuild",
+    "install": "prebuild-install --backend cmake-js --runtime napi || cmake-js rebuild",
     "clean": "yarn clean:cpp && yarn clean:ts",
     "clean:cpp": "cmake-js clean && git clean -fx ./prebuilds",
     "clean:ts": "git clean -fx ./dist ./docs",


### PR DESCRIPTION
This PR adds the SimpleBLE directory and all sub dirs to the npm package. I verified with publish dry run" that it would be added to the package and validated that it can install on a raspi 4 with an "npm pack" version of that.

BTW: A GitHub install would _not_ check the SimpleBLE directory out and so would not work here!

Means: I could test it only with npm pack

fixes #179 

PS: The PR contains two extra commits from trying to get more debug infos, just squash&merge it ...