### PR TITLE
feat: add 'browser' field

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "version": "3.2.1",
   "main": "dist/index.js",
+  "browser": "dist/browser.js",
   "author": "Rob Moran <rob@thegecko.org>",
   "engines": {
     "node": ">=10.20.0 <11.x || >=12.17.0 <13.0 || >=14.0.0"

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,0 +1,35 @@
+/*
+ * Node Web Bluetooth
+ * Copyright (c) Rob Moran
+ *
+ * The MIT License (MIT)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Default bluetooth instance.
+ */
+export const bluetooth = navigator.bluetooth;
+export type Bluetooth = typeof navigator.bluetooth;
+
+/**
+ * Helper methods and enums
+ */
+export * from './uuid';


### PR DESCRIPTION
I'm excited about this one. This adds a `browser` entry to package.json so that when bundling for browsers, it will automatically use `navigator.bluetooth` when importing this package.