### PR TITLE
feat: Allow to acces and choose the Hardware Adapter to use

### DIFF
--- a/examples/list-adapters.js
+++ b/examples/list-adapters.js
@@ -1,0 +1,28 @@
+/*
+* Node Web Bluetooth
+* Copyright (c) 2022 Rob Moran
+*
+* The MIT License (MIT)
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+const webbluetooth = require("../");
+
+console.log(webbluetooth.getSimpleBleHardwareAdapters());

--- a/src/adapters/adapter.ts
+++ b/src/adapters/adapter.ts
@@ -48,6 +48,9 @@ export interface Adapter extends EventEmitter {
     disableNotify: (handle: string) => Promise<void>;
     readDescriptor: (handle: string) => Promise<DataView>;
     writeDescriptor: (handle: string, value: DataView) => Promise<void>;
+    useHardwareAdapter: (adapterIndex: number) => void;
+    getHardwareAdapters: () => Array<HardwareAdapterDetails>;
+}
 
 /** Basic Hardware Details for an Hardware adapter. */
 export interface HardwareAdapterDetails {

--- a/src/adapters/adapter.ts
+++ b/src/adapters/adapter.ts
@@ -48,4 +48,10 @@ export interface Adapter extends EventEmitter {
     disableNotify: (handle: string) => Promise<void>;
     readDescriptor: (handle: string) => Promise<DataView>;
     writeDescriptor: (handle: string, value: DataView) => Promise<void>;
+
+/** Basic Hardware Details for an Hardware adapter. */
+export interface HardwareAdapterDetails {
+    identifier: string;
+    address: string;
+    active: boolean;
 }

--- a/src/adapters/simpleble-adapter.ts
+++ b/src/adapters/simpleble-adapter.ts
@@ -53,6 +53,24 @@ export class SimplebleAdapter extends EventEmitter implements BluetoothAdapter {
     private descriptors = new Map<string, string[]>();
     private charEvents = new Map<string, (value: DataView) => void>();
 
+    getHardwareAdapters() {
+        return getAdapters().map(
+            ({ identifier, address, active }) =>
+                ({ identifier, address, active })
+        );
+    }
+
+    useHardwareAdapter(adapterIndex: number) {
+        if (this.adapter !== undefined) {
+            throw new Error('Can not change adapter after already used.');
+        }
+        const adapter = getAdapters()[adapterIndex];
+        if (adapter === undefined) {
+            throw new Error(`Adapter ${adapterIndex} not found.`);
+        }
+        this.adapter = getAdapters()[adapterIndex];
+    }
+
     private validDevice(device: Partial<BluetoothDeviceImpl>, serviceUUIDs: Array<string>): boolean {
         if (serviceUUIDs.length === 0) {
             // Match any device

--- a/src/adapters/simpleble.ts
+++ b/src/adapters/simpleble.ts
@@ -23,6 +23,8 @@
 * SOFTWARE.
 */
 
+import { HardwareAdapterDetails } from './adapter';
+
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const simpleble = require('bindings')('simpleble.node');
 module.exports = simpleble;

--- a/src/adapters/simpleble.ts
+++ b/src/adapters/simpleble.ts
@@ -85,10 +85,7 @@ export interface Peripheral {
 }
 
 /** SimpleBLE Adapter. */
-export interface Adapter {
-    identifier: string;
-    address: string;
-    active: boolean;
+export interface Adapter extends HardwareAdapterDetails {
     peripherals: Peripheral[];
     pairedPeripherals: Peripheral[];
     scanFor(ms: number): boolean;

--- a/src/bluetooth.ts
+++ b/src/bluetooth.ts
@@ -27,6 +27,7 @@ import { adapter, EVENT_ENABLED } from './adapters';
 import { BluetoothDeviceImpl, BluetoothDeviceEvents } from './device';
 import { BluetoothUUID } from './uuid';
 import { EventDispatcher, DOMEvent } from './events';
+import { HardwareAdapterDetails } from './adapters/adapter';
 
 /**
  * Bluetooth Options interface
@@ -51,6 +52,11 @@ export interface BluetoothOptions {
      * An optional referring device
      */
     referringDevice?: BluetoothDevice;
+
+    /**
+     * An optional BLE Hardware Adapter index to use
+     */
+    hardwareAdapterIndex?: number;
 }
 
 /**
@@ -87,6 +93,9 @@ export class BluetoothImpl extends EventDispatcher<BluetoothEvents> implements B
         this.deviceFound = options.deviceFound;
         if (options.scanTime) {
             this.scanTime = options.scanTime * 1000;
+        }
+        if (typeof options.hardwareAdapterIndex === 'number') {
+            adapter.useHardwareAdapter(options.hardwareAdapterIndex);
         }
 
         adapter.on(EVENT_ENABLED, _value => {
@@ -404,4 +413,8 @@ export class BluetoothImpl extends EventDispatcher<BluetoothEvents> implements B
     public requestLEScan(_options?: BluetoothLEScanOptions): Promise<BluetoothLEScan> {
         throw new Error('requestLEScan error: method not implemented.');
     }
+}
+
+export function getHardwareAdapters(): HardwareAdapterDetails[] {
+    return adapter.getHardwareAdapters();
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@
 * SOFTWARE.
 */
 
-import { BluetoothImpl, BluetoothOptions } from './bluetooth';
+import { BluetoothImpl, BluetoothOptions, getHardwareAdapters } from './bluetooth';
 
 /**
  * Default bluetooth instance synonymous with `navigator.bluetooth`
@@ -33,7 +33,7 @@ export const bluetooth = new BluetoothImpl();
 /**
  * Bluetooth class for creating new instances
  */
-export { BluetoothImpl as Bluetooth, BluetoothOptions };
+export { BluetoothImpl as Bluetooth, BluetoothOptions, getHardwareAdapters as getSimpleBleHardwareAdapters };
 
 /**
  * Helper methods and enums


### PR DESCRIPTION
This PR adds the option to query the available "Hardware BLE Adapters" (I did not wanted to say USB sticks because it could also be UART, so if you have a better name that do not conflict with "Adapter" already used just say :-) ) and define which one to use.

The Constructor of the WebBluetooth class is used to allow to specify the hadware adapter to use as optional option. If the option is not defined it will initialize the adapter HW with id 0 as before too laziely on first real use.

Additionally the method "getSimpleBleHardwareAdapters()" is exported and can be used. I added an example to show the usage. It outputs  the following on my raspi

> [ { identifier: 'hci0', address: 'DC:A6:32:3E:E5:EF', active: false } ]


fixes #178 